### PR TITLE
Ability to specify exact byte value for true boolean.

### DIFF
--- a/src/PeNet.Asn1/Asn1Boolean.cs
+++ b/src/PeNet.Asn1/Asn1Boolean.cs
@@ -7,7 +7,7 @@ namespace PeNet.Asn1 {
         public const string NODE_NAME = "Boolean";
 
         public bool Value { get; set; }
-
+        public static byte TrueValue { get; set; } = 1;
         public Asn1Boolean(bool value) {
             Value = value;
         }
@@ -29,7 +29,7 @@ namespace PeNet.Asn1 {
         }
 
         protected override byte[] GetBytesCore() {
-            return new[] { (byte)(Value ? 1 : 0) };
+            return new[] { (byte)(Value ? TrueValue : 0) };
         }
 
         public new static Asn1Boolean Parse(XElement xNode) {


### PR DESCRIPTION
A very picky consuming BER/ASN1 parser (inside Yocto Linux) wants to have 0xFF for a true value in booleans. So I need to supply that value while writing. This change enables that and won't break any existing behaviour.