### PR TITLE
Lowered .NET Standard dependency to 1.3

### DIFF
--- a/src/PeNet.Asn1/PeNet.Asn1.csproj
+++ b/src/PeNet.Asn1/PeNet.Asn1.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net461;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net461;net40</TargetFrameworks>
     <Authors>Sergey Savchuk, Jan Jansen, Stefan Hausotte</Authors>
     <Company></Company>
     <RepositoryUrl>https://github.com/secana/asn1</RepositoryUrl>


### PR DESCRIPTION
No requirement for apis past .NET Standard 1.3+