### PR TITLE
Add Asn1StringNode abstract class for all Asn1 string nodes

### DIFF
--- a/src/PeNet.Asn1/Asn1BmpString.cs
+++ b/src/PeNet.Asn1/Asn1BmpString.cs
@@ -3,11 +3,15 @@ using System.Text;
 using System.Xml.Linq;
 
 namespace PeNet.Asn1 {
-    public class Asn1BmpString: Asn1Node {
+    public class Asn1BmpString: Asn1StringNode {
 
         public const string NODE_NAME = "BMPString";
 
-        public string Value { get; set; }
+        public override string Value { get; }
+
+        public Asn1BmpString(string value) {
+            Value = value;
+        }
 
         public static Asn1BmpString ReadFrom(Stream stream) {
             if (stream.Length % 2 != 0)
@@ -25,7 +29,7 @@ namespace PeNet.Asn1 {
                 result.Append((char)((firstByte << 8) | secondByte));
             }
 
-            return new Asn1BmpString { Value = result.ToString() };
+            return new Asn1BmpString(result.ToString());
         }
 
         public override Asn1UniversalNodeType NodeType => Asn1UniversalNodeType.BmpString;
@@ -48,9 +52,8 @@ namespace PeNet.Asn1 {
         }
 
         public new static Asn1BmpString Parse(XElement xNode) {
-            var res = new Asn1BmpString();
-            res.Value = xNode.Value.Trim(); //todo should it be trimmed?
-            return res;
+            var value = xNode.Value.Trim(); //todo should it be trimmed?
+            return new Asn1BmpString(value);
         }
     }
 }

--- a/src/PeNet.Asn1/Asn1Ia5String.cs
+++ b/src/PeNet.Asn1/Asn1Ia5String.cs
@@ -3,14 +3,11 @@ using System.Text;
 using System.Xml.Linq;
 
 namespace PeNet.Asn1 {
-    public class Asn1Ia5String : Asn1Node {
+    public class Asn1Ia5String : Asn1StringNode {
 
         public const string NODE_NAME = "IA5";
 
-        public string Value { get; set; }
-
-        public Asn1Ia5String() {
-        }
+        public override string Value { get; }
 
         public Asn1Ia5String(string value) {
             Value = value;
@@ -19,7 +16,7 @@ namespace PeNet.Asn1 {
         public static Asn1Ia5String ReadFrom(Stream stream) {
             var data = new byte[stream.Length];
             stream.Read(data, 0, data.Length);
-            return new Asn1Ia5String { Value = Encoding.ASCII.GetString(data) };
+            return new Asn1Ia5String(Encoding.ASCII.GetString(data));
         }
 
         public override Asn1UniversalNodeType NodeType => Asn1UniversalNodeType.Ia5String;
@@ -35,9 +32,8 @@ namespace PeNet.Asn1 {
         }
 
         public new static Asn1Ia5String Parse(XElement xNode) {
-            var res = new Asn1Ia5String {Value = xNode.Value.Trim()};
-            //todo should it be trimmed?
-            return res;
+            var value = xNode.Value.Trim(); //todo should it be trimmed?
+            return new Asn1Ia5String(value);
         }
     }
 }

--- a/src/PeNet.Asn1/Asn1NumericString.cs
+++ b/src/PeNet.Asn1/Asn1NumericString.cs
@@ -3,16 +3,20 @@ using System.Text;
 using System.Xml.Linq;
 
 namespace PeNet.Asn1 {
-    public class Asn1NumericString : Asn1Node {
+    public class Asn1NumericString : Asn1StringNode {
 
         public const string NODE_NAME = "NumericString";
 
-        public string Value { get; set; }
+        public override string Value { get; }
+
+        public Asn1NumericString(string value) {
+            Value = value;
+        }
 
         public static Asn1NumericString ReadFrom(Stream stream) {
             var data = new byte[stream.Length];
             stream.Read(data, 0, data.Length);
-            return new Asn1NumericString { Value = Encoding.ASCII.GetString(data) };
+            return new Asn1NumericString(Encoding.ASCII.GetString(data));
         }
 
         public override Asn1UniversalNodeType NodeType => Asn1UniversalNodeType.NumericString;
@@ -28,9 +32,8 @@ namespace PeNet.Asn1 {
         }
 
         public new static Asn1NumericString Parse(XElement xNode) {
-            var res = new Asn1NumericString();
-            res.Value = xNode.Value.Trim(); //todo should it be trimmed?
-            return res;
+            var value = xNode.Value.Trim(); //todo should it be trimmed?
+            return new Asn1NumericString(value);
         }
     }
 }

--- a/src/PeNet.Asn1/Asn1PrintableString.cs
+++ b/src/PeNet.Asn1/Asn1PrintableString.cs
@@ -3,16 +3,20 @@ using System.Text;
 using System.Xml.Linq;
 
 namespace PeNet.Asn1 {
-    public class Asn1PrintableString : Asn1Node {
+    public class Asn1PrintableString : Asn1StringNode {
 
         public const string NODE_NAME = "PrintableString";
 
-        public string Value { get; set; }
+        public override string Value { get; }
+
+        public Asn1PrintableString(string value) {
+            Value = value;
+        }
 
         public static Asn1PrintableString ReadFrom(Stream stream) {
             var data = new byte[stream.Length];
             stream.Read(data, 0, data.Length);
-            return new Asn1PrintableString { Value = Encoding.ASCII.GetString(data) };
+            return new Asn1PrintableString(Encoding.ASCII.GetString(data));
         }
 
         public override Asn1UniversalNodeType NodeType => Asn1UniversalNodeType.PrintableString;
@@ -28,9 +32,8 @@ namespace PeNet.Asn1 {
         }
 
         public new static Asn1PrintableString Parse(XElement xNode) {
-            var res = new Asn1PrintableString();
-            res.Value = xNode.Value.Trim(); //todo should it be trimmed?
-            return res;
+            var value = xNode.Value.Trim(); //todo should it be trimmed?
+            return new Asn1PrintableString(value);
         }
     }
 }

--- a/src/PeNet.Asn1/Asn1StringNode.cs
+++ b/src/PeNet.Asn1/Asn1StringNode.cs
@@ -1,0 +1,7 @@
+namespace PeNet.Asn1
+{
+    public abstract class Asn1StringNode : Asn1Node
+    {
+        public abstract string Value { get; }
+    }
+}

--- a/src/PeNet.Asn1/Asn1Utf8String.cs
+++ b/src/PeNet.Asn1/Asn1Utf8String.cs
@@ -3,14 +3,11 @@ using System.Text;
 using System.Xml.Linq;
 
 namespace PeNet.Asn1 {
-    public class Asn1Utf8String : Asn1Node {
+    public class Asn1Utf8String : Asn1StringNode {
 
         public const string NODE_NAME = "UTF8";
 
-        public string Value { get; set; }
-
-        public Asn1Utf8String() {
-        }
+        public override string Value { get; }
 
         public Asn1Utf8String(string value) {
             Value = value;
@@ -19,7 +16,7 @@ namespace PeNet.Asn1 {
         public static Asn1Utf8String ReadFrom(Stream stream) {
             var data = new byte[stream.Length];
             stream.Read(data, 0, data.Length);
-            return new Asn1Utf8String { Value = Encoding.UTF8.GetString(data) };
+            return new Asn1Utf8String(Encoding.UTF8.GetString(data));
         }
 
         public override Asn1UniversalNodeType NodeType => Asn1UniversalNodeType.Utf8String;
@@ -35,9 +32,8 @@ namespace PeNet.Asn1 {
         }
 
         public new static Asn1Utf8String Parse(XElement xNode) {
-            var res = new Asn1Utf8String();
-            res.Value = xNode.Value.Trim(); //todo should it be trimmed?
-            return res;
+            var value = xNode.Value.Trim(); //todo should it be trimmed?
+            return new Asn1Utf8String(value);
         }
     }
 }

--- a/test/PeNet.Asn1_Test/Asn1BmpStringTests.cs
+++ b/test/PeNet.Asn1_Test/Asn1BmpStringTests.cs
@@ -17,7 +17,7 @@ namespace PeNet.Asn1_Test {
 
         [Fact]
         public void WriteTest() {
-            var node = new Asn1BmpString { Value = "г. Ижевск, пер. Северный, д. 61" };
+            var node = new Asn1BmpString("г. Ижевск, пер. Северный, д. 61");
             var data = node.GetBytes();
             AreEqual(_etalon, data);
         }

--- a/test/PeNet.Asn1_Test/Asn1NumericStringTests.cs
+++ b/test/PeNet.Asn1_Test/Asn1NumericStringTests.cs
@@ -17,7 +17,7 @@ namespace PeNet.Asn1_Test {
 
         [Fact]
         public void WriteTest() {
-            var node = new Asn1NumericString { Value = "304741704700129" };
+            var node = new Asn1NumericString("304741704700129");
             var data = node.GetBytes();
             AreEqual(_etalon, data);
         }

--- a/test/PeNet.Asn1_Test/Asn1PrintableStringTests.cs
+++ b/test/PeNet.Asn1_Test/Asn1PrintableStringTests.cs
@@ -17,7 +17,7 @@ namespace PeNet.Asn1_Test {
 
         [Fact]
         public void WriteTest() {
-            var node = new Asn1PrintableString { Value = "TestOrg" };
+            var node = new Asn1PrintableString("TestOrg");
             var data = node.GetBytes();
             AreEqual(_etalon, data);
         }

--- a/test/PeNet.Asn1_Test/Asn1SequenceTests.cs
+++ b/test/PeNet.Asn1_Test/Asn1SequenceTests.cs
@@ -19,7 +19,7 @@ namespace PeNet.Asn1_Test {
         public void WriteTest() {
             var node = new Asn1Sequence();
             node.Nodes.Add(new Asn1ObjectIdentifier("2.5.4.10"));
-            node.Nodes.Add(new Asn1PrintableString { Value = "TestOrg" });
+            node.Nodes.Add(new Asn1PrintableString("TestOrg"));
             var data = node.GetBytes();
             AreEqual(_etalon, data);
         }

--- a/test/PeNet.Asn1_Test/Asn1SetTest.cs
+++ b/test/PeNet.Asn1_Test/Asn1SetTest.cs
@@ -18,8 +18,8 @@ namespace PeNet.Asn1_Test {
         [Fact]
         public void WriteTest() {
             var node = new Asn1Set();
-            node.Nodes.Add(new Asn1ObjectIdentifier ("2.5.4.10"));
-            node.Nodes.Add(new Asn1PrintableString { Value = "TestOrg" });
+            node.Nodes.Add(new Asn1ObjectIdentifier("2.5.4.10"));
+            node.Nodes.Add(new Asn1PrintableString("TestOrg"));
             var data = node.GetBytes();
             AreEqual(_etalon, data);
         }

--- a/test/PeNet.Asn1_Test/Asn1StringTests.cs
+++ b/test/PeNet.Asn1_Test/Asn1StringTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.IO;
+using PeNet.Asn1;
+using Xunit;
+
+namespace PeNet.Asn1_Test
+{
+    public class Asn1StringTests
+    {
+        [Fact]
+        public void Filter_On_Asn1StringNode()
+        {
+            var cert = File.ReadAllBytes(@"./test_files/pidgin.pkcs7");
+            var node = Asn1Node.ReadNode(cert);
+            var organizationalUnitNames = FindObjectIdentifiers(node, Asn1ObjectIdentifier.OrganizationalUnitName);
+
+            Assert.Equal(2, organizationalUnitNames.Count);
+            Assert.Contains(organizationalUnitNames, s => s == "Secure Digital Certificate Signing");
+            Assert.Contains(organizationalUnitNames, s => s == "http://www.usertrust.com");
+        }
+
+        private static IReadOnlyCollection<string> FindObjectIdentifiers(Asn1Node node, Asn1ObjectIdentifier oid)
+        {
+            var results = new HashSet<string>();
+            FindObjectIdentifiers(node, oid, results);
+            return results;
+        }
+
+        private static void FindObjectIdentifiers(Asn1Node node, Asn1ObjectIdentifier oid, ICollection<string> results)
+        {
+            var nodes = node.Nodes;
+            if (nodes.Count == 2 && nodes[0] is Asn1ObjectIdentifier objectIdentifier && objectIdentifier == oid && nodes[1] is Asn1StringNode stringNode)
+            {
+                results.Add(stringNode.Value);
+            }
+            foreach (var child in nodes)
+            {
+                FindObjectIdentifiers(child, oid, results);
+            }
+        }
+    }
+}

--- a/test/PeNet.Asn1_Test/PublicApi.verified.txt
+++ b/test/PeNet.Asn1_Test/PublicApi.verified.txt
@@ -14,13 +14,13 @@
         public new static PeNet.Asn1.Asn1BitString Parse(System.Xml.Linq.XElement xNode) { }
         public static PeNet.Asn1.Asn1BitString ReadFrom(System.IO.Stream stream) { }
     }
-    public class Asn1BmpString : PeNet.Asn1.Asn1Node
+    public class Asn1BmpString : PeNet.Asn1.Asn1StringNode
     {
         public const string NODE_NAME = "BMPString";
-        public Asn1BmpString() { }
+        public Asn1BmpString(string value) { }
         public override PeNet.Asn1.Asn1UniversalNodeType NodeType { get; }
         public override PeNet.Asn1.Asn1TagForm TagForm { get; }
-        public string Value { get; set; }
+        public override string Value { get; }
         protected override byte[] GetBytesCore() { }
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public new static PeNet.Asn1.Asn1BmpString Parse(System.Xml.Linq.XElement xNode) { }
@@ -62,14 +62,13 @@
         public new static PeNet.Asn1.Asn1CustomNode Parse(System.Xml.Linq.XElement xNode) { }
         public static PeNet.Asn1.Asn1CustomNode ReadFrom(PeNet.Asn1.Asn1UniversalNodeType type, PeNet.Asn1.Asn1TagForm tagForm, System.IO.Stream stream) { }
     }
-    public class Asn1Ia5String : PeNet.Asn1.Asn1Node
+    public class Asn1Ia5String : PeNet.Asn1.Asn1StringNode
     {
         public const string NODE_NAME = "IA5";
-        public Asn1Ia5String() { }
         public Asn1Ia5String(string value) { }
         public override PeNet.Asn1.Asn1UniversalNodeType NodeType { get; }
         public override PeNet.Asn1.Asn1TagForm TagForm { get; }
-        public string Value { get; set; }
+        public override string Value { get; }
         protected override byte[] GetBytesCore() { }
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public new static PeNet.Asn1.Asn1Ia5String Parse(System.Xml.Linq.XElement xNode) { }
@@ -122,13 +121,13 @@
         public new static PeNet.Asn1.Asn1Null Parse(System.Xml.Linq.XElement xNode) { }
         public static PeNet.Asn1.Asn1Null ReadFrom(System.IO.Stream stream) { }
     }
-    public class Asn1NumericString : PeNet.Asn1.Asn1Node
+    public class Asn1NumericString : PeNet.Asn1.Asn1StringNode
     {
         public const string NODE_NAME = "NumericString";
-        public Asn1NumericString() { }
+        public Asn1NumericString(string value) { }
         public override PeNet.Asn1.Asn1UniversalNodeType NodeType { get; }
         public override PeNet.Asn1.Asn1TagForm TagForm { get; }
-        public string Value { get; set; }
+        public override string Value { get; }
         protected override byte[] GetBytesCore() { }
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public new static PeNet.Asn1.Asn1NumericString Parse(System.Xml.Linq.XElement xNode) { }
@@ -191,13 +190,13 @@
     {
         public Asn1ParsingException(string message) { }
     }
-    public class Asn1PrintableString : PeNet.Asn1.Asn1Node
+    public class Asn1PrintableString : PeNet.Asn1.Asn1StringNode
     {
         public const string NODE_NAME = "PrintableString";
-        public Asn1PrintableString() { }
+        public Asn1PrintableString(string value) { }
         public override PeNet.Asn1.Asn1UniversalNodeType NodeType { get; }
         public override PeNet.Asn1.Asn1TagForm TagForm { get; }
-        public string Value { get; set; }
+        public override string Value { get; }
         protected override byte[] GetBytesCore() { }
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public new static PeNet.Asn1.Asn1PrintableString Parse(System.Xml.Linq.XElement xNode) { }
@@ -229,6 +228,11 @@
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public new static PeNet.Asn1.Asn1Set Parse(System.Xml.Linq.XElement xNode) { }
         public static PeNet.Asn1.Asn1Set ReadFrom(System.IO.Stream stream) { }
+    }
+    public abstract class Asn1StringNode : PeNet.Asn1.Asn1Node
+    {
+        protected Asn1StringNode() { }
+        public abstract string Value { get; }
     }
     public enum Asn1TagClass : byte
     {
@@ -283,14 +287,13 @@
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public static PeNet.Asn1.Asn1UtcTime ReadFrom(System.IO.Stream stream) { }
     }
-    public class Asn1Utf8String : PeNet.Asn1.Asn1Node
+    public class Asn1Utf8String : PeNet.Asn1.Asn1StringNode
     {
         public const string NODE_NAME = "UTF8";
-        public Asn1Utf8String() { }
         public Asn1Utf8String(string value) { }
         public override PeNet.Asn1.Asn1UniversalNodeType NodeType { get; }
         public override PeNet.Asn1.Asn1TagForm TagForm { get; }
-        public string Value { get; set; }
+        public override string Value { get; }
         protected override byte[] GetBytesCore() { }
         protected override System.Xml.Linq.XElement ToXElementCore() { }
         public new static PeNet.Asn1.Asn1Utf8String Parse(System.Xml.Linq.XElement xNode) { }


### PR DESCRIPTION
Note that this is a breaking change the PeNet.Asn1 version should be bumped to 2.0.0 in order to follow [SemVer][1] rules.

[1]: https://semver.org